### PR TITLE
cross platform tab replacement

### DIFF
--- a/vim-plugins-profile.sh
+++ b/vim-plugins-profile.sh
@@ -35,7 +35,7 @@ echo "Parsing vim startup profile..."
 grep 'plugged' $logfile > tmp.log
 awk -F\: '{print $1}' tmp.log > tmp1.log
 awk -F\: '{print $2}' tmp.log | awk -F\: '{print $2}' tmp.log | sed "s/.*${plugDir}\///g"|sed 's/\/.*//g' > tmp2.log
-paste tmp1.log tmp2.log |sed 's/\s\+/,/g' > profile.csv
+paste -d ',' tmp1.log tmp2.log | tr -s ' ' ',' > profile.csv
 rm tmp.log tmp1.log tmp2.log $logfile
 
 


### PR DESCRIPTION
OSX sed does not support the standard GNU tab escape, use cross compatible tr to replace tabs instead