### PR TITLE
fix `vim-plugins-profile.sh: line 29: return: can only `return' from …

### DIFF
--- a/vim-plugins-profile.sh
+++ b/vim-plugins-profile.sh
@@ -26,7 +26,7 @@ else
   echo "Cannot tell your plugin-manager. Adjust this bash script\n"
   echo "to meet your own needs for now."
   echo 'Cue: `plugDir` variable would be a good starting place.'
-  return
+  exit 1
 fi
 
 


### PR DESCRIPTION
`$vim-plugins-profile.sh: line 29: return: can only ```return' from a function or sourced script`