### PR TITLE
vim-plugins-profile.rb: check Ruby version.

### DIFF
--- a/vim-plugins-profile.rb
+++ b/vim-plugins-profile.rb
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 
+# detect Ruby version
+if RUBY_VERSION < "2.1"
+    puts "vim-plugins-profile requires Ruby >= 2.1."
+    exit!
+end
+
 PLOT_WIDTH = 120
 LOG = "vim-plugins-profile.#{$$}.log"
 


### PR DESCRIPTION
Since this script uses Ruby 2.1 only features,
I add a checking for Ruby version.
When running with Ruby < 2.1,
it exits immediately with an error message.