### PR TITLE
fixed escape character

### DIFF
--- a/vim-plugins-profile.sh
+++ b/vim-plugins-profile.sh
@@ -58,7 +58,7 @@ echo "Crunching data and generating profile plot ..."
 
 # Check if R is available
 echo " "
-type R > /dev/null 2>&1 || { echo >&2 "Package R is required but it's not installed. \nPlease install R using your package manager, \nor check out cran.r-project.org for instructions. \nAborting."; exit 1; }
+type R > /dev/null 2>&1 || { printf >&2 "Package R is required but it's not installed. \nPlease install R using your package manager, \nor check out cran.r-project.org for instructions. \nAborting."; exit 1; }
 
 
 # Still here? Great! Let's move on!


### PR DESCRIPTION
In the previous version, if one were to not have R installed, the program would echo out the literal "Package R is required but it's not installed. \nPlease install R using your package manager, \nor check out cran.r-project.org for instructions. \nAborting." I fixed it by using `printf` instead of `echo`